### PR TITLE
Fix Kindle clock freeze

### DIFF
--- a/literaryclock.sh
+++ b/literaryclock.sh
@@ -43,6 +43,7 @@ get_image_for_time() {
 }
 
 while true; do
+    lipc-set-prop com.lab126.powerd preventScreenSaver 1
     RAW_HOUR=$(date +%H)
     MIN=$(date +%M)
 


### PR DESCRIPTION
## Summary
- keep calling `lipc-set-prop ... preventScreenSaver` each loop so the device stays awake

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a4bf482488326afee843f60928015