### PR TITLE
Improve screen size detection and time overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kindle LitClock
 
-This repository contains a very small Kindle extension that displays an Urdu literary clock on Kindle e-ink devices. The clock shows an image with a literary quote for the current time and overlays the digital time text using [`fbink`](https://github.com/NiLuJe/FBInk).
+This repository contains a very small Kindle extension that displays an Urdu literary clock on Kindle e-ink devices. The clock shows an image with a literary quote for the current time and overlays the digital time using [`fbink`](https://github.com/NiLuJe/FBInk). The script now queries `fbink -i` at startup to detect the display resolution, falling back to `800x600` if parsing fails.
 
 ## Repository contents
 
@@ -20,6 +20,10 @@ sh literaryclock.sh
 ```
 
 Stop the clock by terminating the script (for example using `pkill -f literaryclock.sh`).
+
+The script positions the rotated time text near the right edge of the display.
+Its coordinates are calculated from the detected resolution (`X = WIDTH - 40`,
+`Y = HEIGHT / 2`) and it uses a font size of 40 for clarity.
 
 ## Notes
 

--- a/literaryclock.sh
+++ b/literaryclock.sh
@@ -8,6 +8,27 @@ IMG_DIR="$EXTDIR/images"
 FBINK="/mnt/us/extensions/bin/fbink"
 LOG="$EXTDIR/clock.log"
 
+# Read screen width and height via fbink; fall back to 800x600
+get_screen_size() {
+    local info size
+    info=$("$FBINK" -i 2>/dev/null)
+    size=$(echo "$info" | grep -m1 -o '[0-9]\+x[0-9]\+')
+    WIDTH=$(echo "$size" | cut -d'x' -f1)
+    HEIGHT=$(echo "$size" | cut -d'x' -f2)
+    if [ -z "$WIDTH" ] || [ -z "$HEIGHT" ]; then
+        WIDTH=800
+        HEIGHT=600
+    fi
+}
+
+# Determine screen size once at startup
+get_screen_size
+
+# Calculate placement of the time text
+TIME_X=$((WIDTH - 40))
+TIME_Y=$((HEIGHT / 2))
+TIME_FONT=40
+
 echo "$(date '+%F %T') [INFO] Clock started" >> "$LOG"
 
 get_image_for_time() {
@@ -65,7 +86,7 @@ while true; do
     # Draw rotated time text over image
     TIME=$(printf "%02d:%02d" "$HOUR" "$MIN")
     echo "$(date '+%F %T') [INFO] Displaying time text: $TIME" >> "$LOG"
-    $FBINK -q -m -y 20 -x 400 -S -r cw -s 28 "$TIME"
+    $FBINK -q -m -y "$TIME_Y" -x "$TIME_X" -S -r cw -s "$TIME_FONT" "$TIME"
 
     sleep 60
 done


### PR DESCRIPTION
## Summary
- detect display resolution using `fbink -i`
- compute placement of rotated time text from detected width/height
- increase time font size
- document the new behaviour

## Testing
- `sh -n literaryclock.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a5c3446208326abdcb9eb8117b045